### PR TITLE
Add PDF export to the SH-ESP32 docs

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -8,3 +8,12 @@
   <a href="https://github.com/hatlabs/discussions/discussions">Discussion</a>
 </nav>
 {% endblock %}
+
+{% block content %}
+{% if page.url_to_print_page %}
+  <a href="{{ page.url_to_print_page }}" title="Print or save as PDF" class="md-content__button md-icon">
+    {% include ".icons/material/printer.svg" %}
+  </a>
+{% endif %}
+{{ super() }}
+{% endblock %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,6 +30,11 @@ theme:
 
 plugins:
   - search
+  - print-site:
+      add_cover_page: true
+      add_print_site_banner: true
+      add_to_navigation: false
+      print_page_title: "Sailor Hat with ESP32"
 
 markdown_extensions:
   - admonition

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,4 +3,8 @@ name = "sh-esp32-docs"
 version = "0.1.0"
 description = "Sailor Hat with ESP32 documentation"
 requires-python = ">=3.11"
-dependencies = ["mkdocs-material>=9.5", "click<8.3"]
+dependencies = [
+    "mkdocs-material>=9.5",
+    "click<8.3",
+    "mkdocs-print-site-plugin>=2.8",
+]

--- a/uv.lock
+++ b/uv.lock
@@ -339,6 +339,18 @@ wheels = [
 ]
 
 [[package]]
+name = "mkdocs-print-site-plugin"
+version = "2.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mkdocs-material" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/18/5c71f48b83191fb30cc58617fea20f56647eaa6cafd06a7fb34c738c5acb/mkdocs_print_site_plugin-2.8.tar.gz", hash = "sha256:ab1c89cdb468352975e3bb3bb0ef25dcc2bb88931b03f173206dc95ab02f843f", size = 231688, upload-time = "2025-08-03T14:15:07.579Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/3e/7513f2f37c563da65d1b91781e047f4a1c0ceac8206d4f6042428428e4ad/mkdocs_print_site_plugin-2.8-py3-none-any.whl", hash = "sha256:838bd0a9b7141c11c0f1fdaa51ffe70c35740bec1f07c0806f8018e92f93f9da", size = 21477, upload-time = "2025-08-03T14:15:06.301Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -497,12 +509,14 @@ source = { virtual = "." }
 dependencies = [
     { name = "click" },
     { name = "mkdocs-material" },
+    { name = "mkdocs-print-site-plugin" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = "<8.3" },
     { name = "mkdocs-material", specifier = ">=9.5" },
+    { name = "mkdocs-print-site-plugin", specifier = ">=2.8" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

Readers want an offline/printable copy of the guide. This adds a one-click path from any page to a PDF.

## How

Uses [mkdocs-print-site-plugin](https://timvink.github.io/mkdocs-print-site-plugin/): a printer icon on every page (top-right, beside the edit pencil) links to a combined `/print_page/` that aggregates the whole guide with a cover page and an auto-numbered TOC. A banner on that page instructs the reader to export via **File > Print > Save as PDF** — the browser renders the PDF, so diagrams and CSS come out exactly as on screen.

This approach adds **no CI dependencies** — `uv sync` picks up the new package and the existing strict build is unchanged. Same change as the HALPI2 docs (hatlabs/halpi2#24).

## Verified

- `uv run mkdocs build --strict` → exit 0, no new warnings
- Printer button renders on every page without colliding with the edit button
- Print page produces cover + banner + full aggregated guide

🤖 Generated with [Claude Code](https://claude.com/claude-code)
